### PR TITLE
allow CMAKE options `GISMO_BUILD_EXAMPLES` and `GISMO_BUILD_UNITTESTS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,19 +45,15 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/src"
 add_definitions(-DELAST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/filedata/")
 
 # add example files
-add_custom_target(${PROJECT_NAME}-examples)
-aux_cpp_directory(${CMAKE_CURRENT_SOURCE_DIR}/examples FILES)
-foreach(file ${FILES})
-    add_gismo_executable(${file})
-    get_filename_component(tarname ${file} NAME_WE) # name without extension
-    set_property(TEST ${tarname} PROPERTY LABELS "${PROJECT_NAME}")
-    set_target_properties(${tarname} PROPERTIES FOLDER "${PROJECT_NAME}")
-    add_dependencies(${PROJECT_NAME}-examples ${tarname})
-    # install the example executables (optionally)
-    install(TARGETS ${tarname} DESTINATION "${BIN_INSTALL_DIR}" COMPONENT exe OPTIONAL)
-endforeach(file ${FILES})
+if(GISMO_BUILD_EXAMPLES)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
+else()
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples EXCLUDE_FROM_ALL)
+endif(GISMO_BUILD_EXAMPLES)
 
 # add unittests
-aux_gs_cpp_directory(${PROJECT_SOURCE_DIR}/unittests unittests_SRCS)
-set(gismo_UNITTESTS ${gismo_UNITTESTS} ${unittests_SRCS}
-  CACHE INTERNAL "gismo list of unittests")
+if(GISMO_BUILD_UNITTESTS)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unittests)
+else()
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unittests EXCLUDE_FROM_ALL)
+endif(GISMO_BUILD_UNITTESTS)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,18 @@
+######################################################################
+## CMakeLists.txt --- gsUnstructuredSplines/examples
+## This file is part of the G+Smo library.
+##
+######################################################################
+
+# add example files
+add_custom_target(${PROJECT_NAME}-examples)
+aux_cpp_directory(${CMAKE_CURRENT_SOURCE_DIR} FILES)
+foreach(file ${FILES})
+    add_gismo_executable(${file})
+    get_filename_component(tarname ${file} NAME_WE) # name without extension
+    set_property(TEST ${tarname} PROPERTY LABELS "${PROJECT_NAME}")
+    set_target_properties(${tarname} PROPERTIES FOLDER "${PROJECT_NAME}")
+    add_dependencies(${PROJECT_NAME}-examples ${tarname})
+    # install the example executables (optionally)
+    install(TARGETS ${tarname} DESTINATION "${BIN_INSTALL_DIR}" COMPONENT exe OPTIONAL)
+endforeach(file ${FILES})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,0 +1,10 @@
+######################################################################
+## CMakeLists.txt --- gsUnstructuredSplines/unittests
+## This file is part of the G+Smo library.
+##
+######################################################################
+
+# add example files
+aux_gs_cpp_directory(${PROJECT_SOURCE_DIR} unittests_SRCS)
+set(gismo_UNITTESTS ${gismo_UNITTESTS} ${unittests_SRCS}
+  CACHE INTERNAL "gismo list of unittests")


### PR DESCRIPTION
Enables the use of the options `GISMO_BUILD_EXAMPLES` and `GISMO_BUILD_UNITTESTS`.
Closing issue #19 