### PR TITLE
Fix compilation of examples

### DIFF
--- a/examples/kirchhoff-Love_weak_multipatch_buckling_example.cpp
+++ b/examples/kirchhoff-Love_weak_multipatch_buckling_example.cpp
@@ -20,7 +20,9 @@
 #include <gsKLShell/src/gsThinShellUtils.h>
 #endif
 
+#ifdef gsSpectra_ENABLED
 #include <gsSpectra/gsSpectra.h>
+#endif
 
 using namespace gismo;
 


### PR DESCRIPTION
This commit, together with the following, fix compiler warnings and errors:
75ccc7cf5b788b8b7ef785b178c5a98bc52154d5
5669587a1778b06adf78b8a3d91b05e7238f8e07
fcde73f06399d64ee9ab97e1b0aaa9e62e912993

This PR closes #6

Excuse me for directly pushing the previous commits in `main`.

